### PR TITLE
Fix documentation and spacing inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Documentation: [![](https://img.shields.io/badge/docs-latest-blue.svg)](https://
 
 ## Overview
 
-[`Dispatcher.jl`](https://invenia.github.io/Dispatcher.jl/latest/index.html) builds the graph of julia computations and submits jobs via the julia client to the  [`dask.distributed scheduler`](https://distributed.readthedocs.io/), which is in charge of determining when and where to schedule jobs on the julia workers. Thus, the computations are scheduled and executed efficiently.
+[`Dispatcher.jl`](https://invenia.github.io/Dispatcher.jl/latest/index.html) builds the graph of julia computations and submits jobs via the julia client to the  [`dask.distributed scheduler`](https://distributed.readthedocs.io/), which is in charge of determining when and where to schedule jobs on the julia workers. Thus, the computations can be scheduled and executed efficiently.
 
 ## Frequently Asked Questions
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,7 +8,7 @@ DaskDistributedDispatcher integrates `Dispatcher.jl` with the python `dask.distr
 
 ## Overview
 
-[`Dispatcher.jl`](https://invenia.github.io/Dispatcher.jl/latest/index.html) builds the graph of julia computations and submits jobs via the julia client to the  [`dask.distributed scheduler`](https://distributed.readthedocs.io/), which is in charge of determining when and where to schedule jobs on the julia workers. Thus, the computations are scheduled and executed efficiently.
+[`Dispatcher.jl`](https://invenia.github.io/Dispatcher.jl/latest/index.html) builds the graph of julia computations and submits jobs via the julia client to the  [`dask.distributed scheduler`](https://distributed.readthedocs.io/), which is in charge of determining when and where to schedule jobs on the julia workers. Thus, the computations can be scheduled and executed efficiently.
 
 ## Frequently Asked Questions
 

--- a/docs/src/pages/manual.md
+++ b/docs/src/pages/manual.md
@@ -2,7 +2,7 @@
 
 ## Motivation
 
-The primary reason for integrating the [`dask.distributed`](https://distributed.readthedocs.io/en/latest/index.html) scheduler with [`Dispatcher.jl`](https://invenia.github.io/Dispatcher.jl/stable/) is to be able to guarantee a stronger degree of effiency for computations run and to allow for fluctuating worker resources. Note that removing workers from the worker pool may cause errors when fetching results. Only remove workers once you no longer need access to their information.
+The primary reason for integrating the [`dask.distributed`](https://distributed.readthedocs.io/en/latest/index.html) scheduler with [`Dispatcher.jl`](https://invenia.github.io/Dispatcher.jl/stable/) is to be able to guarantee a stronger degree of effiency for computations run and to allow for fluctuating worker resources. (Note that removing workers from the worker pool may cause errors when fetching results. Only remove workers once you no longer need access to their information.)
 
 Using the `dask-scheduler` and executing compuations in a distributed manner can
 [`add overhead for simple tasks`]
@@ -36,7 +36,7 @@ $ dask-scheduler
 Scheduler started at 127.0.0.1:8786
 ```
 
-Then, in a julia session set up a [`cluster`](https://docs.julialang.org/en/stable/manual/parallel-computing/#clustermanagers) of julia processes and initialize the workers by providing them with the dask-scheduler's tcp address:
+Then, in a julia session, set up a [`cluster`](https://docs.julialang.org/en/stable/manual/parallel-computing/#clustermanagers) of julia processes and initialize the workers by providing them with the `dask-scheduler`'s tcp address:
 
 ```julia
 using DaskDistributedDispatcher
@@ -45,7 +45,7 @@ addprocs(3)
 @everywhere using DaskDistributedDispatcher
 
 for i in 1:3
-  @spawn Worker("127.0.0.1:8786")
+    @spawn Worker("127.0.0.1:8786")
 end
 ```
 
@@ -61,8 +61,8 @@ data = [1, 2, 3]
 
 ctx = @dispatch_context begin
     a = @op 1 + 2
-	x = @op a + 3
-	y = @op a + 1
+    x = @op a + 3
+    y = @op a + 1
 
     result = @op x * y
 end
@@ -93,7 +93,7 @@ It is possible to bypass the [`DaskExecutor`](@ref) by accessing its `client` va
 When done your computations, to get the `dask-scheduler` to reset and delete all previously computed values without restarting the [`Worker`](@ref)s and the `dask-scheduler` call:
 
 ```julia
-reset(executor)
+reset!(executor)
 ```
 
 

--- a/docs/src/pages/workers.md
+++ b/docs/src/pages/workers.md
@@ -32,8 +32,8 @@ show(::IO, ::Worker)
 ## Internals
 
 ```@docs
-DaskDistributedDispatcher.start_worker(::Worker)
-DaskDistributedDispatcher.register_worker(::Worker)
+DaskDistributedDispatcher.start(::Worker)
+DaskDistributedDispatcher.register(::Worker)
 DaskDistributedDispatcher.handle_comm(::Worker, ::TCPSocket)
 DaskDistributedDispatcher.close(::Worker)
 DaskDistributedDispatcher.get_data(::Worker; ::Array, ::String)

--- a/src/client.jl
+++ b/src/client.jl
@@ -9,11 +9,11 @@ results. Should only be used directly for advanced workflows. See [`DaskExecutor
 instead for normal usage.
 
 # Fields
-- `nodes::Dict{String, DispatchNode}`: maps keys to their dispatcher `DispatchNode`
+- `nodes::Dict{Array{UInt8, 1}, Void}`: previously submitted keys
 - `id::String`: this client's identifier
 - `status::String`: status of this client
 - `scheduler_address::Address`: the dask-distributed scheduler ip address and port info
-- ` scheduler::Rpc`: manager for discrete send/receive open connections to the scheduler
+- `scheduler::Rpc`: manager for discrete send/receive open connections to the scheduler
 - `connecting_to_scheduler::Bool`: if client is currently trying to connect to the scheduler
 - `scheduler_comm::Nullable{BatchedSend}`: batched stream for communication with scheduler
 - `pending_msg_buffer::Array`: pending msgs to send on the batched stream

--- a/src/executor.jl
+++ b/src/executor.jl
@@ -29,7 +29,7 @@ type DaskExecutor <: Executor
 end
 
 """
-    DaskExecutor(scheduler_address::String="\$(getipaddr()):8786")
+    DaskExecutor(scheduler_address::String="127.0.0.1:8786")
 
 Return a new [`DaskExecutor`](@ref). The `scheduler_address` only needs to be included if
 the [`dask-scheduler`]
@@ -128,7 +128,7 @@ fetch(unwrap(results[2]))  # 4
 To delete all previously computed information from the workers:
 
 ```julia
-reset(exec)
+reset!(exec)
 ```
 
 ## Advanced Workflows
@@ -140,7 +140,7 @@ results, or replicate data across all workers. See [`Client`](@ref) for more det
 recommened to start with a [`DaskExecutor`](@ref) and access its `client` field if needed
 later on.
 """
-function DaskExecutor(scheduler_address::String="$(getipaddr()):8786")
+function DaskExecutor(scheduler_address::String="127.0.0.1:8786")
     client = Client(scheduler_address)
 
     return DaskExecutor(0, Function[], client, scheduler_address)

--- a/src/worker.jl
+++ b/src/worker.jl
@@ -213,7 +213,7 @@ function Worker(scheduler_address::String="127.0.0.1:8786")
         Set{String}(),  # missing_dep_flight
     )
 
-    start_worker(worker)
+    start(worker)
     return worker
 end
 
@@ -254,11 +254,11 @@ end
 ##############################         ADMIN FUNCTIONS        ##############################
 
 """
-    start_worker(worker::Worker)
+    start(worker::Worker)
 
 Coordinate a worker's startup.
 """
-function start_worker(worker::Worker)
+function start(worker::Worker)
     worker.status == "starting" || return
 
     start_listening(worker)
@@ -268,15 +268,15 @@ function start_worker(worker::Worker)
         "waiting to connect to: \"$(worker.scheduler_address)\""
     )
 
-    register_worker(worker)
+    register(worker)
 end
 
 """
-    register_worker(worker::Worker)
+    register(worker::Worker)
 
 Register a `Worker` with the dask-scheduler process.
 """
-function register_worker(worker::Worker)
+function register(worker::Worker)
     @schedule begin
         response = send_recv(
             worker.scheduler,

--- a/src/worker.jl
+++ b/src/worker.jl
@@ -14,7 +14,7 @@ communicates state to the scheduler.
 - `address::Address`:: ip address and port that this worker is listening on
 - `listener::Base.TCPServer`: tcp server that listens for incoming connections
 
-- `scheduler_address::Address`: the dask-distributed scheduler ip address and port information
+- `scheduler_address::Address`: the dask-distributed scheduler ip address and port info
 - `batched_stream::Nullable{BatchedSend}`: batched stream for communication with scheduler
 - `scheduler::Rpc`: manager for discrete send/receive open connections to the scheduler
 - `connection_pool::ConnectionPool`: manages connections to peers
@@ -84,7 +84,7 @@ type Worker <: Server
 end
 
 """
-    Worker(scheduler_address::String="\$(getipaddr()):8786")
+    Worker(scheduler_address::String="127.0.0.1:8786")
 
 Create a `Worker` that listens on a random port between 1024 and 9000 for incoming
 messages. By default if the scheduler's address is not provided it assumes that the
@@ -124,8 +124,8 @@ Worker("tcp://127.0.0.1:8786")
 ```
 
 No further actions are needed directly on the Worker's themselves as they will communicate
-with the `dask-scheduler` independently. New `Worker`s can be added/removed at any time during
-execution. There usually should be at least one `Worker` to run computations.
+with the `dask-scheduler` independently. New `Worker`s can be added/removed at any time
+during execution. There usually should be at least one `Worker` to run computations.
 
 ## Cleanup
 
@@ -145,7 +145,7 @@ still needs the lost data.
 via `rmprocs` from the julia cluster. It is cleaner but not necessary to explicity call
 `shutdown` if planning to remove a `Worker`.
 """
-function Worker(scheduler_address::String="$(getipaddr()):8786")
+function Worker(scheduler_address::String="127.0.0.1:8786")
     scheduler_address = Address(scheduler_address)
     port, listener = listenany(rand(1024:9000))
     worker_address = Address(getipaddr(), port)
@@ -535,7 +535,8 @@ Add a task to the worker's list of tasks to be computed.
 - `who_has::Dict`: Map of dependent keys and the addresses of the workers that have them.
 - `nbytes::Dict`: Map of the number of bytes of the dependent key's data.
 - `duration::String`: The estimated computation cost of the given key. Defaults to "0.5".
-- `resource_restrictions::Dict`: Resources required by a task. Should always be an empty Dict.
+- `resource_restrictions::Dict`: Resources required by the task for computation. Should
+    always be an empty Dict since specifying resources is not currently supported.
 - `func::Union{String, Array{UInt8,1}}`: The callable funtion for the task, serialized.
 - `args::Union{String, Array{UInt8,1}}`: The arguments for the task, serialized.
 - `kwargs::Union{String, Array{UInt8,1}}`: The keyword arguments for the task, serialized.
@@ -1106,7 +1107,7 @@ end
 Transition task with identifier `key` to finish_state from its current state.
 """
 function transition(worker::Worker, key::String, finish_state::String; kwargs...)
-     # Ensure the task hasn't been released (cancelled) by the scheduler
+    # Ensure the task hasn't been released (cancelled) by the scheduler
     if haskey(worker.task_state, key)
         start_state = worker.task_state[key]
 


### PR DESCRIPTION
Fix some inconsistencies I came across in the documentation and spacing. Also added some type information that will be continued in #9.

Also renamed `start_worker` and `register_worker` for issue #11 