### PR TITLE
Refactor the dask scheduler teardown to be less error-prone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ install:
 
 before_script:
   - dask-scheduler &
+  - SCHEDULER_PID=$!
 
 # uncomment the following lines to override the default test script
 script:
@@ -52,7 +53,7 @@ script:
 - julia -e 'Pkg.clone(pwd()); Pkg.build("DaskDistributedDispatcher"); Pkg.test("DaskDistributedDispatcher"; coverage=true)'
 
 after_script:
-  - python ./test/teardown.py
+  - kill $SCHEDULER_PID
 
 after_success:
   # push coverage results to Codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ addons:
     packages:
       - hdf5-tools
 
+git:
+  depth: 999999
+
 matrix:
   allow_failures:
     - julia: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ script:
 - julia -e 'Pkg.clone(pwd()); Pkg.build("DaskDistributedDispatcher"); Pkg.test("DaskDistributedDispatcher"; coverage=true)'
 
 after_script:
-  - kill $SCHEDULER_PID
+  - kill -s TERM $SCHEDULER_PID
 
 after_success:
   # push coverage results to Codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,9 +45,11 @@ build_script:
   - C:\projects\julia\bin\julia -e "versioninfo();
       Pkg.clone(pwd(), \"DaskDistributedDispatcher\"); Pkg.build(\"DaskDistributedDispatcher\")"
 
+before_test:
+  - ps: $SchedulerProcess = Start-Process dask-scheduler -PassThru
+
 test_script:
-  - ps: Start-Process dask-scheduler -PassThru
   - C:\projects\julia\bin\julia -e "Pkg.test(\"DaskDistributedDispatcher\")"
 
 after_test:
-  - python ./test/teardown.py
+  - ps: Stop-Process -Id $SchedulerProcess.Id

--- a/test/teardown.py
+++ b/test/teardown.py
@@ -1,9 +1,0 @@
-from distributed import Client
-client = Client("tcp://127.0.0.1:8786")
-
-client.loop.add_callback(client.scheduler.retire_workers, close_workers=True)
-client.loop.add_callback(client.scheduler.terminate)
-client.run_on_scheduler(lambda dask_scheduler: dask_scheduler.loop.stop())
-
-# Source:
-# https://stackoverflow.com/questions/44021931/stopping-dask-ssh-created-scheduler-from-the-client-interface


### PR DESCRIPTION
Kill the scheduler process directly after tests have run instead of using the python workaround. 