### PR TITLE
Install HDF5 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ julia:
   - 0.6
   - nightly
 
+addons:
+  apt:
+    packages:
+      - hdf5-tools
+
 matrix:
   allow_failures:
     - julia: nightly


### PR DESCRIPTION
This way BinDeps won't fail to install it in some situations.