### PR TITLE
Change usage of `sleep` to `yield`

### DIFF
--- a/src/comm.jl
+++ b/src/comm.jl
@@ -310,13 +310,13 @@ Send the messages in `batchsend.buffer` every `interval` milliseconds.
 function background_send(batchedsend::BatchedSend)
     @schedule while !batchedsend.please_stop
         if isempty(batchedsend.buffer)
-            sleep(batchedsend.interval)
+            yield()
             continue
         end
 
         payload, batchedsend.buffer = batchedsend.buffer, Vector{Dict{String, Any}}()
         send_msg(batchedsend.comm, payload)
-        sleep(batchedsend.interval)
+        yield()
     end
 end
 


### PR DESCRIPTION
When @shashi mentioned that there was time spent in `sleep` I realized that `sleep` is probably not necessary and `yield` will suffice. We'll see if the CI tests agree.